### PR TITLE
Fix Ord for U256

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target/
 bench/
 Cargo.lock
+.idea
+.vscode

--- a/num/src/cmp.rs
+++ b/num/src/cmp.rs
@@ -12,13 +12,20 @@
 use crate::U256;
 use core::cmp::Ordering;
 
+impl Ord for U256 {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.high().cmp(other.high()) {
+            Ordering::Equal => self.low().cmp(other.low()),
+            ordering => ordering,
+        }
+    }
+}
+
 impl PartialOrd for U256 {
     #[inline]
-    fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
-        Some(match self.high().cmp(rhs.high()) {
-            Ordering::Equal => self.low().cmp(rhs.low()),
-            ordering => ordering,
-        })
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 
@@ -37,5 +44,21 @@ impl PartialOrd<u128> for U256 {
         } else {
             Ordering::Greater
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::U256;
+    use core::cmp::Ordering;
+
+    #[test]
+    fn cmp() {
+        // 1e38
+        let x = U256::from_words(0, 100000000000000000000000000000000000000);
+        // 1e48
+        let y = U256::from_words(2938735877, 18960114910927365649471927446130393088);
+        assert!(x < y);
+        assert_eq!(x.cmp(&y), Ordering::Less);
     }
 }

--- a/num/src/lib.rs
+++ b/num/src/lib.rs
@@ -21,7 +21,7 @@ mod uint;
 pub use self::convert::AsU256;
 
 /// A 256-bit unsigned integer type.
-#[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq)]
+#[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
 #[repr(transparent)]
 pub struct U256(pub [u128; 2]);
 


### PR DESCRIPTION
Derived `Ord` for `U256` is incorrect in Little Endian platform. 

Because in LE, U256 is `U256([lo, hi])`, derived `Ord` actually compares `[u128; 2]`, so it's going to compare `lo` first. That is why the error happened.

For example:

```Rust
// 1e38
let x = U256::from_words(0, 100000000000000000000000000000000000000);
// 1e48
let y = U256::from_words(2938735877, 18960114910927365649471927446130393088);
assert!(x < y); // OK
assert_eq!(x.cmp(&y), Ordering::Less); // Panic!!!
```